### PR TITLE
Convert figma design to shopify liquid theme

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="js" lang="{{ request.locale.iso_code }}">
+<html class="js" lang="{{ request.locale.iso_code }}" dir="{% if request.locale.iso_code contains 'ar' or request.locale.iso_code contains 'he' or request.locale.iso_code contains 'fa' or request.locale.iso_code contains 'ur' %}rtl{% else %}ltr{% endif %}">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/sections/custom-hero.liquid
+++ b/sections/custom-hero.liquid
@@ -1,0 +1,287 @@
+{{ 'section-image-banner.css' | asset_url | stylesheet_tag }}
+
+{%- style -%}
+  .section-{{ section.id }}-padding {
+    padding-top: {{ section.settings.padding_top | times: 0.75 | round: 0 }}px;
+    padding-bottom: {{ section.settings.padding_bottom | times: 0.75 | round: 0 }}px;
+  }
+
+  @media screen and (min-width: 750px) {
+    .section-{{ section.id }}-padding {
+      padding-top: {{ section.settings.padding_top }}px;
+      padding-bottom: {{ section.settings.padding_bottom }}px;
+    }
+  }
+
+  .hero-{{ section.id }} {
+    position: relative;
+    overflow: hidden;
+  }
+
+  .hero-{{ section.id }}__media {
+    position: relative;
+  }
+
+  .hero-{{ section.id }}__media img,
+  .hero-{{ section.id }}__media video {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  .hero-{{ section.id }}__overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0,0,0, {{ section.settings.image_overlay_opacity | divided_by: 100.0 }});
+    pointer-events: none;
+  }
+
+  .hero-{{ section.id }}__content-wrap {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    align-items: center;
+    justify-items: center;
+  }
+
+  .hero-{{ section.id }}__content {
+    width: 100%;
+    max-width: 900px;
+  }
+
+  .hero-{{ section.id }}__content--top-left { align-items: start; justify-items: start; }
+  .hero-{{ section.id }}__content--top-center { align-items: start; justify-items: center; }
+  .hero-{{ section.id }}__content--top-right { align-items: start; justify-items: end; }
+  .hero-{{ section.id }}__content--middle-left { align-items: center; justify-items: start; }
+  .hero-{{ section.id }}__content--middle-center { align-items: center; justify-items: center; }
+  .hero-{{ section.id }}__content--middle-right { align-items: center; justify-items: end; }
+  .hero-{{ section.id }}__content--bottom-left { align-items: end; justify-items: start; }
+  .hero-{{ section.id }}__content--bottom-center { align-items: end; justify-items: center; }
+  .hero-{{ section.id }}__content--bottom-right { align-items: end; justify-items: end; }
+
+  .hero-{{ section.id }}__badge {
+    display: inline-block;
+    padding: 6px 10px;
+    font-size: 12px;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    border-radius: 999px;
+    background: rgba(255,255,255,.15);
+    backdrop-filter: blur(4px);
+  }
+  .hero-{{ section.id }}.hero--small { min-height: 40vh; }
+  .hero-{{ section.id }}.hero--medium { min-height: 60vh; }
+  .hero-{{ section.id }}.hero--large { min-height: 80vh; }
+  .hero-{{ section.id }}.hero--full { min-height: 100vh; }
+{%- endstyle -%}
+
+{%- liquid
+  assign fetch_priority = 'auto'
+  if section.index == 1
+    assign fetch_priority = 'high'
+  endif
+-%}
+
+<div class="isolate section-{{ section.id }}-padding">
+  <div class="hero-{{ section.id }} hero hero--{{ section.settings.image_height }}">
+    <div class="hero-{{ section.id }}__media">
+      {%- if section.settings.image != blank -%}
+        {%- if section.settings.image_behavior == 'ambient' or section.settings.image_behavior == 'zoom-in' -%}
+          {%- assign widths = '198, 432, 642, 900, 1284, 1800' -%}
+          {%- capture sizes -%}
+            (min-width: {{ settings.page_width }}px) {{ settings.page_width }}px,
+            100vw
+          {%- endcapture -%}
+        {%- else -%}
+          {%- assign widths = '375, 550, 750, 1100, 1500, 2200' -%}
+          {%- capture sizes -%}
+            100vw
+          {%- endcapture -%}
+        {%- endif -%}
+        {{ section.settings.image | image_url: width: 2200 | image_tag: sizes: sizes, widths: widths, fetchpriority: fetch_priority }}
+      {%- else -%}
+        {{ 'hero-apparel-1' | placeholder_svg_tag: 'placeholder-svg' }}
+      {%- endif -%}
+      <div class="hero-{{ section.id }}__overlay"></div>
+    </div>
+
+    <div class="hero-{{ section.id }}__content-wrap hero-{{ section.id }}__content--{{ section.settings.desktop_content_position }}">
+      <div class="hero-{{ section.id }}__content content-container color-{{ section.settings.color_scheme }} gradient page-width">
+        {%- for block in section.blocks -%}
+          {%- case block.type -%}
+            {%- when 'badge' -%}
+              {%- if block.settings.text != blank -%}
+                <div class="hero-{{ section.id }}__badge" {{ block.shopify_attributes }}>{{ block.settings.text | escape }}</div>
+              {%- endif -%}
+            {%- when 'heading' -%}
+              <h2 class="inline-richtext {{ block.settings.heading_size }}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}" {{ block.shopify_attributes }}>{{ block.settings.heading }}</h2>
+            {%- when 'text' -%}
+              <div class="rte {% if settings.animations_reveal_on_scroll %}scroll-trigger animate--fade-in{% endif %}" {{ block.shopify_attributes }}>{{ block.settings.text }}</div>
+            {%- when 'buttons' -%}
+              <div class="hero-cta" {{ block.shopify_attributes }}>
+                {%- if block.settings.button_label_1 != blank -%}
+                  <a {% if block.settings.button_link_1 == blank %}role="link" aria-disabled="true"{% else %}href="{{ block.settings.button_link_1 }}"{% endif %} class="button{% if block.settings.button_style_secondary_1 %} button--secondary{% else %} button--primary{% endif %}">{{ block.settings.button_label_1 | escape }}</a>
+                {%- endif -%}
+                {%- if block.settings.button_label_2 != blank -%}
+                  <a {% if block.settings.button_link_2 == blank %}role="link" aria-disabled="true"{% else %}href="{{ block.settings.button_link_2 }}"{% endif %} class="button{% if block.settings.button_style_secondary_2 %} button--secondary{% else %} button--primary{% endif %}">{{ block.settings.button_label_2 | escape }}</a>
+                {%- endif -%}
+              </div>
+          {%- endcase -%}
+        {%- endfor -%}
+      </div>
+    </div>
+  </div>
+</div>
+
+{% schema %}
+{
+  "name": "Custom hero",
+  "tag": "section",
+  "class": "section",
+  "settings": [
+    {
+      "type": "image_picker",
+      "id": "image",
+      "label": "Background image"
+    },
+    {
+      "type": "select",
+      "id": "image_behavior",
+      "label": "Image behavior",
+      "default": "none",
+      "options": [
+        {"value": "none", "label": "None"},
+        {"value": "ambient", "label": "Ambient"},
+        {"value": "zoom-in", "label": "Zoom in"}
+      ]
+    },
+    {
+      "type": "range",
+      "id": "image_overlay_opacity",
+      "min": 0,
+      "max": 100,
+      "step": 5,
+      "unit": "%",
+      "label": "Overlay opacity",
+      "default": 30
+    },
+    {
+      "type": "select",
+      "id": "image_height",
+      "label": "Section height",
+      "default": "large",
+      "options": [
+        {"value": "small", "label": "Small"},
+        {"value": "medium", "label": "Medium"},
+        {"value": "large", "label": "Large"},
+        {"value": "full", "label": "Full viewport"}
+      ]
+    },
+    {
+      "type": "select",
+      "id": "desktop_content_position",
+      "label": "Content position",
+      "default": "middle-center",
+      "options": [
+        {"value": "top-left", "label": "Top left"},
+        {"value": "top-center", "label": "Top center"},
+        {"value": "top-right", "label": "Top right"},
+        {"value": "middle-left", "label": "Middle left"},
+        {"value": "middle-center", "label": "Middle center"},
+        {"value": "middle-right", "label": "Middle right"},
+        {"value": "bottom-left", "label": "Bottom left"},
+        {"value": "bottom-center", "label": "Bottom center"},
+        {"value": "bottom-right", "label": "Bottom right"}
+      ]
+    },
+    {
+      "type": "select",
+      "id": "color_scheme",
+      "label": "Color scheme",
+      "default": "scheme-3",
+      "options": [
+        {"value": "scheme-1", "label": "Scheme 1"},
+        {"value": "scheme-2", "label": "Scheme 2"},
+        {"value": "scheme-3", "label": "Scheme 3"},
+        {"value": "scheme-4", "label": "Scheme 4"}
+      ]
+    },
+    {
+      "type": "range",
+      "id": "padding_top",
+      "min": 0,
+      "max": 120,
+      "step": 4,
+      "unit": "px",
+      "label": "Padding top",
+      "default": 40
+    },
+    {
+      "type": "range",
+      "id": "padding_bottom",
+      "min": 0,
+      "max": 120,
+      "step": 4,
+      "unit": "px",
+      "label": "Padding bottom",
+      "default": 40
+    }
+  ],
+  "blocks": [
+    {
+      "type": "badge",
+      "name": "Badge",
+      "limit": 1,
+      "settings": [
+        {"type": "text", "id": "text", "label": "Badge text", "default": "New"}
+      ]
+    },
+    {
+      "type": "heading",
+      "name": "Heading",
+      "limit": 1,
+      "settings": [
+        {"type": "inline_richtext", "id": "heading", "label": "Heading", "default": "Hero headline"},
+        {"type": "select", "id": "heading_size", "label": "Heading size", "default": "h1", "options": [
+          {"value": "h0", "label": "Display"},
+          {"value": "h1", "label": "H1"},
+          {"value": "h2", "label": "H2"}
+        ]}
+      ]
+    },
+    {
+      "type": "text",
+      "name": "Text",
+      "limit": 1,
+      "settings": [
+        {"type": "richtext", "id": "text", "label": "Text", "default": "<p>Add a short description here.<\/p>"}
+      ]
+    },
+    {
+      "type": "buttons",
+      "name": "Buttons",
+      "limit": 1,
+      "settings": [
+        {"type": "text", "id": "button_label_1", "label": "Primary button label", "default": "Shop now"},
+        {"type": "url", "id": "button_link_1", "label": "Primary button link"},
+        {"type": "checkbox", "id": "button_style_secondary_1", "label": "Use secondary style for primary", "default": false},
+        {"type": "text", "id": "button_label_2", "label": "Secondary button label", "default": "Learn more"},
+        {"type": "url", "id": "button_link_2", "label": "Secondary button link"},
+        {"type": "checkbox", "id": "button_style_secondary_2", "label": "Use secondary style for secondary", "default": true}
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Custom hero",
+      "blocks": [
+        {"type": "badge"},
+        {"type": "heading"},
+        {"type": "text"},
+        {"type": "buttons"}
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/icon-features.liquid
+++ b/sections/icon-features.liquid
@@ -1,0 +1,116 @@
+{%- style -%}
+  .section-{{ section.id }}-padding {
+    padding-top: {{ section.settings.padding_top | times: 0.75 | round: 0 }}px;
+    padding-bottom: {{ section.settings.padding_bottom | times: 0.75 | round: 0 }}px;
+  }
+
+  @media screen and (min-width: 750px) {
+    .section-{{ section.id }}-padding {
+      padding-top: {{ section.settings.padding_top }}px;
+      padding-bottom: {{ section.settings.padding_bottom }}px;
+    }
+  }
+
+  .features-{{ section.id }}__grid {
+    display: grid;
+    grid-template-columns: repeat({{ section.settings.columns_mobile }}, minmax(0, 1fr));
+    gap: 20px;
+  }
+
+  @media screen and (min-width: 750px) {
+    .features-{{ section.id }}__grid {
+      grid-template-columns: repeat({{ section.settings.columns_desktop }}, minmax(0, 1fr));
+      gap: 28px;
+    }
+  }
+
+  .features-{{ section.id }}__item {
+    height: 100%;
+  }
+
+  .features-{{ section.id }}__icon {
+    width: 48px;
+    height: 48px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 10px;
+  }
+{%- endstyle -%}
+
+<div class="isolate{% unless section.settings.full_width %} page-width{% endunless %} section-{{ section.id }}-padding">
+  <div class="content-container color-{{ section.settings.color_scheme }} gradient{% if section.settings.full_width %} content-container--full-width{% endif %}">
+    {%- if section.settings.title != blank -%}
+      <div class="title-wrapper-with-link title-wrapper--self-padded-mobile">
+        <h2 class="title inline-richtext {{ section.settings.heading_size }}">{{ section.settings.title }}</h2>
+      </div>
+    {%- endif -%}
+
+    <div class="features-{{ section.id }}__grid">
+      {%- for block in section.blocks -%}
+        <div class="features-{{ section.id }}__item card card--standard" {{ block.shopify_attributes }}>
+          <div class="card__content">
+            {%- if block.settings.icon != blank -%}
+              <div class="features-{{ section.id }}__icon">
+                {{ block.settings.icon | image_url: width: 96 | image_tag: widths: '48,96' }}
+              </div>
+            {%- endif -%}
+            {%- if block.settings.title != blank -%}
+              <h3 class="h4 inline-richtext">{{ block.settings.title }}</h3>
+            {%- endif -%}
+            {%- if block.settings.text != blank -%}
+              <div class="rte">{{ block.settings.text }}</div>
+            {%- endif -%}
+          </div>
+        </div>
+      {%- endfor -%}
+    </div>
+  </div>
+</div>
+
+{% schema %}
+{
+  "name": "Icon features",
+  "tag": "section",
+  "class": "section",
+  "settings": [
+    {"type": "inline_richtext", "id": "title", "label": "Title", "default": "Why choose us"},
+    {"type": "select", "id": "heading_size", "label": "Heading size", "default": "h2", "options": [
+      {"value": "h2", "label": "H2"},
+      {"value": "h1", "label": "H1"}
+    ]},
+    {"type": "checkbox", "id": "full_width", "label": "Full width", "default": false},
+    {"type": "select", "id": "color_scheme", "label": "Color scheme", "default": "scheme-1", "options": [
+      {"value": "scheme-1", "label": "Scheme 1"},
+      {"value": "scheme-2", "label": "Scheme 2"},
+      {"value": "scheme-3", "label": "Scheme 3"},
+      {"value": "scheme-4", "label": "Scheme 4"}
+    ]},
+    {"type": "range", "id": "columns_desktop", "min": 2, "max": 4, "step": 1, "label": "Columns (desktop)", "default": 3},
+    {"type": "range", "id": "columns_mobile", "min": 1, "max": 2, "step": 1, "label": "Columns (mobile)", "default": 2},
+    {"type": "range", "id": "padding_top", "min": 0, "max": 120, "step": 4, "unit": "px", "label": "Padding top", "default": 40},
+    {"type": "range", "id": "padding_bottom", "min": 0, "max": 120, "step": 4, "unit": "px", "label": "Padding bottom", "default": 40}
+  ],
+  "blocks": [
+    {
+      "type": "feature",
+      "name": "Feature",
+      "settings": [
+        {"type": "image_picker", "id": "icon", "label": "Icon"},
+        {"type": "inline_richtext", "id": "title", "label": "Title", "default": "Feature title"},
+        {"type": "richtext", "id": "text", "label": "Text", "default": "<p>Feature description.<\/p>"}
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Icon features",
+      "blocks": [
+        {"type": "feature"},
+        {"type": "feature"},
+        {"type": "feature"}
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/testimonials.liquid
+++ b/sections/testimonials.liquid
@@ -1,0 +1,128 @@
+{%- style -%}
+  .section-{{ section.id }}-padding {
+    padding-top: {{ section.settings.padding_top | times: 0.75 | round: 0 }}px;
+    padding-bottom: {{ section.settings.padding_bottom | times: 0.75 | round: 0 }}px;
+  }
+
+  @media screen and (min-width: 750px) {
+    .section-{{ section.id }}-padding {
+      padding-top: {{ section.settings.padding_top }}px;
+      padding-bottom: {{ section.settings.padding_bottom }}px;
+    }
+  }
+
+  .testimonials-{{ section.id }}__grid {
+    display: grid;
+    grid-template-columns: repeat({{ section.settings.columns_mobile }}, minmax(0, 1fr));
+    gap: 20px;
+  }
+
+  @media screen and (min-width: 750px) {
+    .testimonials-{{ section.id }}__grid {
+      grid-template-columns: repeat({{ section.settings.columns_desktop }}, minmax(0, 1fr));
+      gap: 28px;
+    }
+  }
+
+  .testimonial-card {
+    height: 100%;
+  }
+
+  .testimonial-card__rating {
+    display: inline-flex;
+    gap: 2px;
+    margin-bottom: 8px;
+  }
+{%- endstyle -%}
+
+<div class="isolate page-width section-{{ section.id }}-padding">
+  <div class="content-container color-{{ section.settings.color_scheme }} gradient">
+    {%- if section.settings.title != blank -%}
+      <div class="title-wrapper-with-link title-wrapper--self-padded-mobile">
+        <h2 class="title inline-richtext {{ section.settings.heading_size }}">{{ section.settings.title }}</h2>
+      </div>
+    {%- endif -%}
+
+    <div class="testimonials-{{ section.id }}__grid">
+      {%- for block in section.blocks -%}
+        <div class="testimonial-card card card--standard" {{ block.shopify_attributes }}>
+          <div class="card__content">
+            {%- if section.settings.show_rating and block.settings.rating > 0 -%}
+              <div class="testimonial-card__rating">
+                {%- for i in (1..block.settings.rating) -%}
+                  {{ 'icon-star.svg' | asset_url | image_tag: class: 'icon' }}
+                {%- endfor -%}
+              </div>
+            {%- endif -%}
+            {%- if block.settings.quote != blank -%}
+              <div class="rte">{{ block.settings.quote }}</div>
+            {%- endif -%}
+            <div class="spacer" style="height:12px"></div>
+            <div class="testimonial-card__author" style="display:flex;gap:12px;align-items:center;">
+              {%- if block.settings.avatar != blank -%}
+                {{ block.settings.avatar | image_url: width: 80 | image_tag: widths: '48,80', style: 'border-radius:9999px;width:48px;height:48px;object-fit:cover;' }}
+              {%- endif -%}
+              <div>
+                {%- if block.settings.author != blank -%}
+                  <div class="h5">{{ block.settings.author }}</div>
+                {%- endif -%}
+                {%- if block.settings.role != blank -%}
+                  <div class="caption">{{ block.settings.role }}</div>
+                {%- endif -%}
+              </div>
+            </div>
+          </div>
+        </div>
+      {%- endfor -%}
+    </div>
+  </div>
+</div>
+
+{% schema %}
+{
+  "name": "Testimonials",
+  "tag": "section",
+  "class": "section",
+  "settings": [
+    {"type": "inline_richtext", "id": "title", "label": "Title", "default": "What our customers say"},
+    {"type": "select", "id": "heading_size", "label": "Heading size", "default": "h2", "options": [
+      {"value": "h2", "label": "H2"},
+      {"value": "h1", "label": "H1"}
+    ]},
+    {"type": "checkbox", "id": "show_rating", "label": "Show rating", "default": true},
+    {"type": "range", "id": "columns_desktop", "min": 2, "max": 4, "step": 1, "label": "Columns (desktop)", "default": 3},
+    {"type": "range", "id": "columns_mobile", "min": 1, "max": 2, "step": 1, "label": "Columns (mobile)", "default": 1},
+    {"type": "select", "id": "color_scheme", "label": "Color scheme", "default": "scheme-1", "options": [
+      {"value": "scheme-1", "label": "Scheme 1"},
+      {"value": "scheme-2", "label": "Scheme 2"},
+      {"value": "scheme-3", "label": "Scheme 3"},
+      {"value": "scheme-4", "label": "Scheme 4"}
+    ]},
+    {"type": "range", "id": "padding_top", "min": 0, "max": 120, "step": 4, "unit": "px", "label": "Padding top", "default": 44},
+    {"type": "range", "id": "padding_bottom", "min": 0, "max": 120, "step": 4, "unit": "px", "label": "Padding bottom", "default": 44}
+  ],
+  "blocks": [
+    {
+      "type": "testimonial",
+      "name": "Testimonial",
+      "settings": [
+        {"type": "richtext", "id": "quote", "label": "Quote", "default": "<p>Short testimonial text goes here.<\/p>"},
+        {"type": "text", "id": "author", "label": "Author", "default": "Jane Doe"},
+        {"type": "text", "id": "role", "label": "Role / Company"},
+        {"type": "image_picker", "id": "avatar", "label": "Avatar"},
+        {"type": "range", "id": "rating", "min": 0, "max": 5, "step": 1, "label": "Rating", "default": 5}
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Testimonials",
+      "blocks": [
+        {"type": "testimonial"},
+        {"type": "testimonial"},
+        {"type": "testimonial"}
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/templates/page.faq.json
+++ b/templates/page.faq.json
@@ -1,0 +1,29 @@
+{
+  "sections": {
+    "faq": {
+      "type": "collapsible-content",
+      "blocks": {
+        "q1": {"type": "collapsible_row", "settings": {"heading": "سؤال متكرر 1", "row_content": "<p>إجابة مختصرة عن السؤال.<\/p>"}},
+        "q2": {"type": "collapsible_row", "settings": {"heading": "سؤال متكرر 2", "row_content": "<p>تفاصيل الإجابة.<\/p>"}},
+        "q3": {"type": "collapsible_row", "settings": {"heading": "سؤال متكرر 3", "row_content": "<p>تفاصيل إضافية.<\/p>"}}
+      },
+      "block_order": ["q1", "q2", "q3"],
+      "settings": {
+        "caption": "",
+        "heading": "الأسئلة الشائعة",
+        "heading_size": "h2",
+        "heading_alignment": "left",
+        "image": null,
+        "image_ratio": "adapt",
+        "desktop_layout": "image_first",
+        "color_scheme": "scheme-1",
+        "container_color_scheme": "scheme-1",
+        "open_first_collapsible_row": true,
+        "layout": "section",
+        "padding_top": 44,
+        "padding_bottom": 44
+      }
+    }
+  },
+  "order": ["faq"]
+}

--- a/templates/page.landing.json
+++ b/templates/page.landing.json
@@ -1,0 +1,148 @@
+{
+  "sections": {
+    "hero": {
+      "type": "custom-hero",
+      "blocks": {
+        "badge": { "type": "badge", "settings": { "text": "New" } },
+        "heading": { "type": "heading", "settings": { "heading": "عنوان رئيسي جذاب", "heading_size": "h0" } },
+        "text": { "type": "text", "settings": { "text": "<p>وصف قصير لما تقدمه — سطر أو سطران كحد أقصى.<\/p>" } },
+        "buttons": { "type": "buttons", "settings": { "button_label_1": "تسوق الآن", "button_link_1": "shopify:\/\/collections\/all", "button_style_secondary_1": false, "button_label_2": "اعرف المزيد", "button_link_2": "#", "button_style_secondary_2": true } }
+      },
+      "block_order": ["badge", "heading", "text", "buttons"],
+      "settings": {
+        "image": null,
+        "image_behavior": "none",
+        "image_overlay_opacity": 30,
+        "image_height": "large",
+        "desktop_content_position": "middle-center",
+        "color_scheme": "scheme-3",
+        "padding_top": 0,
+        "padding_bottom": 0
+      }
+    },
+    "features": {
+      "type": "icon-features",
+      "blocks": {
+        "feature_1": { "type": "feature", "settings": { "icon": null, "title": "شحن سريع", "text": "<p>توصيل موثوق لكل المناطق.<\/p>" } },
+        "feature_2": { "type": "feature", "settings": { "icon": null, "title": "ضمان الجودة", "text": "<p>منتجات أصلية ومضمونة.<\/p>" } },
+        "feature_3": { "type": "feature", "settings": { "icon": null, "title": "دعم 24\/7", "text": "<p>خدمة عملاء على مدار الساعة.<\/p>" } }
+      },
+      "block_order": ["feature_1", "feature_2", "feature_3"],
+      "settings": {
+        "title": "لماذا تختارنا",
+        "heading_size": "h2",
+        "full_width": false,
+        "color_scheme": "scheme-1",
+        "columns_desktop": 3,
+        "columns_mobile": 2,
+        "padding_top": 44,
+        "padding_bottom": 28
+      }
+    },
+    "image_with_text": {
+      "type": "image-with-text",
+      "blocks": {
+        "heading": { "type": "heading", "settings": { "heading": "قسم صورة مع نص", "heading_size": "h2" } },
+        "text": { "type": "text", "settings": { "text": "<p>استخدم هذا القسم لعرض ميزة أو قصة العلامة.<\/p>" } },
+        "button": { "type": "button", "settings": { "button_label": "اعرف المزيد", "button_link": "#", "button_style_secondary": true } }
+      },
+      "block_order": ["heading", "text", "button"],
+      "settings": {
+        "image": null,
+        "height": "adapt",
+        "desktop_image_width": "medium",
+        "image_behavior": "none",
+        "layout": "image_first",
+        "desktop_content_position": "top",
+        "desktop_content_alignment": "left",
+        "mobile_content_alignment": "left",
+        "content_layout": "no-overlap",
+        "color_scheme": "scheme-1",
+        "section_color_scheme": "scheme-1",
+        "padding_top": 36,
+        "padding_bottom": 36
+      }
+    },
+    "featured_collection": {
+      "type": "featured-collection",
+      "settings": {
+        "title": "منتجات مميزة",
+        "heading_size": "h2",
+        "description": "",
+        "show_description": false,
+        "description_style": "body",
+        "collection": "all",
+        "products_to_show": 8,
+        "columns_desktop": 4,
+        "color_scheme": "scheme-1",
+        "full_width": false,
+        "show_view_all": true,
+        "view_all_style": "solid",
+        "enable_desktop_slider": false,
+        "swipe_on_mobile": false,
+        "image_ratio": "adapt",
+        "image_shape": "default",
+        "show_secondary_image": true,
+        "show_vendor": false,
+        "show_rating": false,
+        "quick_add": "none",
+        "columns_mobile": "2",
+        "padding_top": 44,
+        "padding_bottom": 36
+      }
+    },
+    "testimonials": {
+      "type": "testimonials",
+      "blocks": {
+        "t1": { "type": "testimonial", "settings": { "quote": "<p>تجربة رائعة!<\/p>", "author": "محمد", "role": "عميل" , "rating": 5 } },
+        "t2": { "type": "testimonial", "settings": { "quote": "<p>خدمة ممتازة وشحن سريع.<\/p>", "author": "سارة", "role": "عميل" , "rating": 5 } },
+        "t3": { "type": "testimonial", "settings": { "quote": "<p>سأكرر الطلب أكيد.<\/p>", "author": "أحمد", "role": "عميل" , "rating": 4 } }
+      },
+      "block_order": ["t1", "t2", "t3"],
+      "settings": {
+        "title": "آراء العملاء",
+        "heading_size": "h2",
+        "show_rating": true,
+        "columns_desktop": 3,
+        "columns_mobile": 1,
+        "color_scheme": "scheme-1",
+        "padding_top": 44,
+        "padding_bottom": 44
+      }
+    },
+    "cta": {
+      "type": "rich-text",
+      "blocks": {
+        "heading": { "type": "heading", "settings": { "heading": "نداء لاتخاذ إجراء", "heading_size": "h2" } },
+        "text": { "type": "text", "settings": { "text": "<p>نص قصير يحفز المستخدم على الضغط.<\/p>" } },
+        "button": { "type": "button", "settings": { "button_label": "ابدأ الآن", "button_link": "shopify:\/\/collections\/all", "button_style_secondary": false } }
+      },
+      "block_order": ["heading", "text", "button"],
+      "settings": {
+        "desktop_content_position": "center",
+        "content_alignment": "center",
+        "full_width": false,
+        "color_scheme": "scheme-3",
+        "padding_top": 44,
+        "padding_bottom": 44
+      }
+    },
+    "newsletter": {
+      "type": "newsletter",
+      "settings": {
+        "color_scheme": "scheme-1",
+        "padding_top": 44,
+        "padding_bottom": 64
+      }
+    }
+  },
+  "order": [
+    "hero",
+    "features",
+    "image_with_text",
+    "featured_collection",
+    "testimonials",
+    "cta",
+    "newsletter"
+  ]
+}


### PR DESCRIPTION
Adds new Shopify Liquid sections and templates for a flexible landing page and FAQ, with RTL support, to implement the Figma design.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7d03423-7afc-491d-82e0-3b0463f3de45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f7d03423-7afc-491d-82e0-3b0463f3de45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

